### PR TITLE
Fix a permanent NaN latch in the clock servo

### DIFF
--- a/src/flexptp/servo/kalman_filter.c
+++ b/src/flexptp/servo/kalman_filter.c
@@ -303,6 +303,12 @@ float kalman_filter_run(int32_t dt, PtpServoAuxInput *pAux) {
         goto retain_cycle_data;
     }
 
+    // A non-positive measured Sync period divides by zero below, in both the skew
+    // measurement and insert_DT(). Skip the cycle rather than poison the state.
+    if (pAux->measSyncPeriodNs <= 0) {
+        goto retain_cycle_data;
+    }
+
     /* ---- PREPARE THE PARAMETERS ---- */
 
     // calculate input data
@@ -364,6 +370,15 @@ float kalman_filter_run(int32_t dt, PtpServoAuxInput *pAux) {
     double tuning_coefficient = (fabs(x[0]) > FAST_TUNING_THRESHOLD) ? FAST_TUNING_COEFFICIENT : CALM_TUNING_COEFFICIENT;
     double tuning = -x[1] + ((-x[0] * 1E+09 / pAux->measSyncPeriodNs) * tuning_coefficient);
     tuning_ppb = tuning * 1E+09;
+
+    // Guard against a non-finite state. NaN and infinity propagate through every
+    // subsequent update, so one bad sample latches the filter permanently: the tuning
+    // value stays NaN, which prints as 0.0000 and converts to a zero clock correction.
+    // The servo then looks healthy while the clock free-runs. Restart instead.
+    if (!isfinite(tuning_ppb) || !isfinite(x[0]) || !isfinite(x[1])) {
+        kalman_filter_reset();
+        return 0.0f;
+    }
 
     // feed back tuning
     u[0] = 0;

--- a/src/flexptp/slave.c
+++ b/src/flexptp/slave.c
@@ -32,6 +32,13 @@
  * @param tuning_ppb clock tuning in PPB
  */
 static void ptp_tune_clock(float tuning_ppb) {
+    // Refuse a non-finite tuning value. Converting NaN or infinity to an integer is
+    // unpredictable (ARM yields 0, x86 yields INT64_MIN), so a single poisoned sample
+    // would either freeze the addend for ever or destroy it outright.
+    if (!isfinite(tuning_ppb)) {
+        return;
+    }
+
 #ifdef PTP_ADDEND_INTERFACE
     int64_t compAddend = (int64_t)S.hwclock.addend + (int64_t)(tuning_ppb * PTP_ADDEND_CORR_PER_PPB_F); // compute addend value
     S.hwclock.addend = MIN(compAddend, 0xFFFFFFFF);                                                     // limit to 32-bit range
@@ -125,6 +132,15 @@ static void ptp_perform_correction() {
     TimestampI measSyncPeriod;
     subTime(&measSyncPeriod, &syncMa, &(S.slave.prevSyncMa));
     int64_t measSyncPeriod_ns = nsI(&measSyncPeriod);
+
+    // A Sync cycle that did not advance in master time - the same Sync processed twice, or
+    // two Syncs bearing the same originTimestamp - gives a zero or negative measured period.
+    // Every servo divides by this value, so passing it on produces NaN and, because NaN
+    // propagates through the filter state, silently disables clock correction from then on.
+    if (measSyncPeriod_ns <= 0) {
+        CLILOG(S.logging.info, "Sync cycle did not advance in master time; cycle skipped.\n");
+        goto retain_cycle_data;
+    }
 
     // ------------------------------
 


### PR DESCRIPTION
A Sync cycle that does not advance in master time — the same Sync processed twice, or two Syncs carrying the same `originTimestamp` — gives `measSyncPeriodNs <= 0`. Every servo divides by that, so the cycle produces NaN, and NaN propagates through the Kalman filter's state, so a single bad sample disables clock correction permanently.

What makes this worth fixing rather than tolerating is that it is silent. The servo goes on printing a correction of `0.0000` for ever, which is exactly what a perfectly locked slave prints, while the clock free-runs underneath. No error, no state change, no counter that moves.

Three independent guards: reject the bad period before it reaches a servo, reject a non-finite tuning value before it reaches the hardware clock, and reset the filter if its state goes non-finite anyway. Each alone prevents the latch; together they also let the filter recover rather than merely refuse to break.

Nothing here is specific to a port, an RTOS or a network stack.

Found while porting flexPTP to an STM32H563 (NUCLEO-H563ZI) running ThreadX through the CMSIS-RTOS2 binding with lwIP as the network stack, in an application that samples two SCH16T IMUs at 8 kHz and timestamps them off the PTP-disciplined clock. This has been running with the fix applied since.

## The change

One commit, based on `master` `76aaf67` (RC1.0-11 — current `HEAD` when this was written). It rebases cleanly onto `pdel_fix` too, so this can target either branch.

1. Fix permanent NaN latch in the clock servo after a repeated Sync

Rebasing or squashing to taste is fine by me — say the word and I will reshape it.
