### PR TITLE
CMSIS-RTOS2: stop blocking in the enqueue paths

### DIFF
--- a/src/flexptp/task_ptp.c
+++ b/src/flexptp/task_ptp.c
@@ -503,8 +503,32 @@ void ptp_receive_enqueue(const void *pPayload, uint32_t len, uint32_t ts_sec, ui
         xQueueSend(sRxPacketFIFO, &uid, portMAX_DELAY);       // send index
         xQueueSend(sNotificationFIFO, &notif, portMAX_DELAY); // send notification
 #elif defined(FLEXPTP_CMSIS_OS2)
-        osMessageQueuePut(sRxPacketFIFO, &uid, 0, osWaitForever);
-        osMessageQueuePut(sNotificationFIFO, &notif, 0, osWaitForever);
+        /* Timeout 0, NOT osWaitForever. THIS ONE DEADLOCKS THE WHOLE NETWORK STACK.
+         *
+         * ptp_receive_cb() reaches here, and lwIP calls that from tcpip_thread with
+         * LOCK_TCPIP_CORE HELD. Blocking therefore puts the thread that owns the lwIP core lock
+         * to sleep still holding it, and the wait is circular:
+         *
+         *   tcpip_thread holds the core lock and blocks on sRxPacketFIFO being full;
+         *   sRxPacketFIFO is drained only by task_ptp();
+         *   task_ptp(), to send anything, calls ptp_transmit() -> LOCK_TCPIP_CORE.
+         *
+         * Neither moves and nothing times out. Every user of the lock stops for ever: ARP, ICMP,
+         * every UDP sender in the application, and PTP itself, which falls out of SLAVE and stays
+         * there. Only a reset recovers it. Measured on a NUCLEO-H563ZI by flooding the link for
+         * 120 s; both application senders were caught blocked in LOCK_TCPIP_CORE while the
+         * hardware sampling path carried on perfectly.
+         *
+         * Dropping a PTP message when the queue is full is the correct failure. The protocol is
+         * built for loss -- the servo already tolerates missing Sync and Delay_Resp, which is what
+         * the master timeout counter is for -- and the block is reclaimed by msgb_tick() when its
+         * RX_TTL_MS expires, so nothing leaks. */
+        if (osMessageQueuePut(sRxPacketFIFO, &uid, 0, 0U) == osOK) {
+            /* Index first, notification second, as in ptp_event_enqueue(): the notification only
+               says "something is available", never which, so a lost notification is picked up by
+               the next one. The reverse order strands task_ptp() reading an empty FIFO. */
+            osMessageQueuePut(sNotificationFIFO, &notif, 0, 0U);
+        }
 #elif defined(FLEXPTP_LINUX)
         write(sRxPacketFIFO[1], &uid, sizeof(uint32_t));
 #elif defined(FLEXPTP_OSLESS)
@@ -535,8 +559,12 @@ bool ptp_transmit_enqueue(const RawPtpMessage *pMsg) {
             xQueueSend(sNotificationFIFO, &notif, portMAX_DELAY);
         }
 #elif defined(FLEXPTP_CMSIS_OS2)
-        osMessageQueuePut(sTxPacketFIFO, &uid, 0, osWaitForever);
-        osMessageQueuePut(sNotificationFIFO, &notif, 0, osWaitForever);
+        /* Timeout 0, for the reason ptp_event_enqueue() gives above: master.c and common.c
+         * enqueue from task_ptp() itself, which is the only thread that drains sTxPacketFIFO.
+         * Blocking there is a self-deadlock the moment the queue fills. */
+        if (osMessageQueuePut(sTxPacketFIFO, &uid, 0, 0U) == osOK) {
+            osMessageQueuePut(sNotificationFIFO, &notif, 0, 0U);
+        }
 #elif defined(FLEXPTP_LINUX)
         write(sTxPacketFIFO[1], &uid, sizeof(uint32_t));
 #elif defined(FLEXPTP_OSLESS)
@@ -569,8 +597,14 @@ void ptp_transmit_timestamp_cb(uint32_t uid, uint32_t seconds, uint32_t nanoseco
         xQueueSend(sNotificationFIFO, &notif, portMAX_DELAY);
     }
 #elif defined(FLEXPTP_CMSIS_OS2)
-    osMessageQueuePut(sTxCbFIFO, &ts, 0, osWaitForever);
-    osMessageQueuePut(sNotificationFIFO, &notif, 0, osWaitForever);
+    /* Timeout 0, because this is reachable FROM AN ISR -- the FreeRTOS arm above says so, with its
+     * xPortIsInsideInterrupt() split. CMSIS-RTOS2 has no such split to make: osMessageQueuePut
+     * with a non-zero timeout is invalid from interrupt context and is rejected outright, so
+     * osWaitForever here does not block, it silently loses every transmit timestamp taken in an
+     * ISR. A timeout of 0 is valid from both contexts and is the only form that works in either. */
+    if (osMessageQueuePut(sTxCbFIFO, &ts, 0, 0U) == osOK) {
+        osMessageQueuePut(sNotificationFIFO, &notif, 0, 0U);
+    }
 #elif defined(FLEXPTP_LINUX)
     write(sTxCbFIFO[1], &ts, sizeof(TxTs));
     sem_post(&sTxCbSem);

--- a/src/flexptp/task_ptp.c
+++ b/src/flexptp/task_ptp.c
@@ -437,9 +437,28 @@ bool ptp_event_enqueue(const PtpCoreEvent *event) {
         xQueueSend(sNotificationFIFO, &notif, portMAX_DELAY);
     }
 #elif defined(FLEXPTP_CMSIS_OS2)
-    ok = osMessageQueuePut(sEventFIFO, event, 0, osWaitForever) == osOK;
+    /* Timeout 0, NOT osWaitForever.
+     *
+     * ptp_heartbeat_tmr_cb() calls this function, and CMSIS-RTOS2 runs osTimer callbacks in
+     * the RTOS's timer thread. That thread may not block: on ThreadX, _txe_queue_send()
+     * returns TX_WAIT_ERROR outright when the caller is &_tx_timer_thread and the wait option
+     * is not TX_NO_WAIT, which the CMSIS-RTOS2 wrapper reports as osErrorTimeout. So with
+     * osWaitForever EVERY heartbeat is rejected, ptp_process_event() never sees
+     * PTP_CEV_HEARTBEAT, ptp_bmca_tick() never runs, and the BMCA FSM is stranded in
+     * INITIALIZING -- where ptp_handle_announce_msg() discards every Announce through its
+     * `default:` arm and no master is ever selected. The same restriction applies to the
+     * FreeRTOS timer service task, where blocking risks deadlocking it instead.
+     *
+     * Dropping an event when the queue is full is the correct failure for a timer callback,
+     * and it also removes a self-deadlock: ptp_bmca_handle_state_change() enqueues from
+     * task_ptp() itself, i.e. from the only thread that drains this queue. */
+    ok = osMessageQueuePut(sEventFIFO, event, 0, 0U) == osOK;
     if (ok) {
-        osMessageQueuePut(sNotificationFIFO, &notif, 0, osWaitForever);
+        /* Event first, notification second, and both non-blocking. If the notification is
+           lost the event is not: it stays queued and is consumed by the next notification,
+           because the notification only says "an event is available", never which one. The
+           reverse order would strand task_ptp() in a blocking read of an empty event FIFO. */
+        osMessageQueuePut(sNotificationFIFO, &notif, 0, 0U);
     }
 #elif defined(FLEXPTP_LINUX)
     size_t len = sizeof(PtpCoreEvent);

--- a/src/flexptp/task_ptp.c
+++ b/src/flexptp/task_ptp.c
@@ -472,6 +472,18 @@ bool ptp_event_enqueue(const PtpCoreEvent *event) {
     return ok;
 }
 
+/* Enqueues refused because a queue was full.
+ *
+ * These exist because the non-blocking puts above turn a hang into a drop, and a drop nobody
+ * counts is just a quieter bug. Read them with ptp_enqueue_drop_stats(). */
+static uint32_t sRxEnqueueDropped, sTxEnqueueDropped, sTxCbEnqueueDropped;
+
+void ptp_enqueue_drop_stats(uint32_t *rx, uint32_t *tx, uint32_t *txCb) {
+    if (rx) { *rx = sRxEnqueueDropped; }
+    if (tx) { *tx = sTxEnqueueDropped; }
+    if (txCb) { *txCb = sTxCbEnqueueDropped; }
+}
+
 // put ptp message onto processing queue
 void ptp_receive_enqueue(const void *pPayload, uint32_t len, uint32_t ts_sec, uint32_t ts_ns, int tp) {
     // only consider messages received on the matching transport layer
@@ -528,6 +540,8 @@ void ptp_receive_enqueue(const void *pPayload, uint32_t len, uint32_t ts_sec, ui
                says "something is available", never which, so a lost notification is picked up by
                the next one. The reverse order strands task_ptp() reading an empty FIFO. */
             osMessageQueuePut(sNotificationFIFO, &notif, 0, 0U);
+        } else {
+            sRxEnqueueDropped++;
         }
 #elif defined(FLEXPTP_LINUX)
         write(sRxPacketFIFO[1], &uid, sizeof(uint32_t));
@@ -564,6 +578,8 @@ bool ptp_transmit_enqueue(const RawPtpMessage *pMsg) {
          * Blocking there is a self-deadlock the moment the queue fills. */
         if (osMessageQueuePut(sTxPacketFIFO, &uid, 0, 0U) == osOK) {
             osMessageQueuePut(sNotificationFIFO, &notif, 0, 0U);
+        } else {
+            sTxEnqueueDropped++;
         }
 #elif defined(FLEXPTP_LINUX)
         write(sTxPacketFIFO[1], &uid, sizeof(uint32_t));
@@ -604,6 +620,8 @@ void ptp_transmit_timestamp_cb(uint32_t uid, uint32_t seconds, uint32_t nanoseco
      * ISR. A timeout of 0 is valid from both contexts and is the only form that works in either. */
     if (osMessageQueuePut(sTxCbFIFO, &ts, 0, 0U) == osOK) {
         osMessageQueuePut(sNotificationFIFO, &notif, 0, 0U);
+    } else {
+        sTxCbEnqueueDropped++;
     }
 #elif defined(FLEXPTP_LINUX)
     write(sTxCbFIFO[1], &ts, sizeof(TxTs));

--- a/src/flexptp/task_ptp.h
+++ b/src/flexptp/task_ptp.h
@@ -60,6 +60,18 @@ bool is_flexPTP_operating();
 void ptp_receive_enqueue(const void *pPayload, uint32_t len, uint32_t ts_sec, uint32_t ts_ns, int tp);
 
 /**
+ * Read the enqueue drop counters.
+ *
+ * The enqueue paths above drop rather than block when a queue is full; these count the
+ * refusals, so a saturated link shows up as a number instead of as silence.
+ *
+ * @param rx   refused receive enqueues, or NULL
+ * @param tx   refused transmit enqueues, or NULL
+ * @param txCb refused transmit-timestamp enqueues, or NULL
+ */
+void ptp_enqueue_drop_stats(uint32_t *rx, uint32_t *tx, uint32_t *txCb);
+
+/**
  * Put a PTP message into the transmit queue.
  * 
  * @param pMsg pointer to raw PTP message. Can be discarded after the function has returned.


### PR DESCRIPTION
Every `osWaitForever` enqueue in `task_ptp.c`'s `FLEXPTP_CMSIS_OS2` branch is reachable from a context that must not block. There are three distinct failures, so there are three patches.

Patch 1 stops PTP working at all, silently: the firmware builds, links, takes an address and never synchronises. `ptp_heartbeat_tmr_cb()` runs in the RTOS timer thread and ThreadX refuses to suspend that thread outright, so every heartbeat was rejected, `ptp_bmca_tick()` never ran, and the BMCA FSM never left `INITIALIZING` — the one state where Announce messages are dropped through a `default:` arm. Receive worked perfectly throughout, which is what made it look like a receive fault for a long time.

Patch 2 is the serious one. lwIP calls `ptp_receive_cb()` from `tcpip_thread` with `LOCK_TCPIP_CORE` held, so blocking there puts the owner of the lwIP core lock to sleep while it still holds the lock, waiting on a queue that only `task_ptp()` drains — and `task_ptp()` needs that same lock to transmit. Nothing times out. ARP, ICMP, every application UDP sender and PTP itself stop for ever; only a reset recovers it. Measured by flooding the NUCLEO's link for 120 s, reproduced 3 of 3, with both application senders caught blocked in `LOCK_TCPIP_CORE` while the 8 kHz sampling path carried on perfectly and the console reported a healthy system. A 30 s flood survives, because the queues have to fill first.

The same patch covers two lesser cases in the same file: a self-deadlock in `ptp_transmit_enqueue()`, whose callers run in `task_ptp()` itself; and `ptp_transmit_timestamp_cb()`, which is reachable from an ISR — as the FreeRTOS arm directly above it acknowledges with its `xPortIsInsideInterrupt()` split. CMSIS-RTOS2 has no such split to make, because `osMessageQueuePut` with a non-zero timeout is invalid from interrupt context and rejected outright. So `osWaitForever` there never blocked; it silently discarded every transmit timestamp taken in an ISR.

Patch 3 counts the resulting drops and exposes them through `ptp_enqueue_drop_stats()`. It is last and separate on purpose: it adds public API, so if you would rather fold it into `stats.c`, surface it as a CLI command, or drop it entirely, that can happen without holding up patches 1 and 2.

One thing I did not change: the FreeRTOS branch has the same shape. `xQueueSend(..., portMAX_DELAY)` from the timer service task risks deadlocking it rather than failing cleanly, and its receive path has the same relationship to `tcpip_thread`. I left it alone because CMSIS-RTOS2 is the binding this port exercises and the only one I could measure, but it is worth a look.

Found while porting flexPTP to an STM32H563 (NUCLEO-H563ZI) running ThreadX through the CMSIS-RTOS2 binding with lwIP as the network stack, in an application that samples two SCH16T IMUs at 8 kHz and timestamps them off the PTP-disciplined clock. This has been running with the fix applied since.

## The change

3 commits, based on `master` `76aaf67` (RC1.0-11 — current `HEAD` when this was written). They rebase cleanly onto `pdel_fix` too, so this can target either branch.

1. CMSIS-RTOS2: do not block in ptp_event_enqueue()
2. CMSIS-RTOS2: do not block in the receive, transmit and TX-timestamp enqueues
3. Count refused enqueues and expose them via ptp_enqueue_drop_stats()

Rebasing or squashing to taste is fine by me — say the word and I will reshape it.
