### PR TITLE
lwIP NSD: check pbuf_alloc() before writing through it

### DIFF
--- a/src/flexptp/port/example_netstack_drivers/nsd_lwip.c
+++ b/src/flexptp/port/example_netstack_drivers/nsd_lwip.c
@@ -112,6 +112,13 @@ void ptp_nsd_transmit_msg(RawPtpMessage *pMsg, uint32_t uid) {
     struct pbuf *p = NULL;
     p = pbuf_alloc((TP == PTP_TP_IPv4) ? PBUF_TRANSPORT : PBUF_LINK, pMsg->size, PBUF_RAM);
 
+    /* pbuf_alloc() returns NULL when lwIP's heap is exhausted, which sustained receive pressure
+     * will do. Dereferencing it here faulted the board rather than dropping a message -- and a
+     * transmit that cannot get memory is exactly the case where dropping is right. */
+    if (p == NULL) {
+        return;
+    }
+
     // fill buffer
     memcpy(p->payload, pMsg->data, pMsg->size);
 


### PR DESCRIPTION
`ptp_transmit()` memcpy'd into the result of `pbuf_alloc()` with no NULL check. lwIP returns NULL when its heap is exhausted, which sustained receive pressure does, so this is a hard fault reachable from the network.

Dropping the message is the right answer — a transmit that cannot get memory is precisely the case the protocol's tolerance of loss exists for.

Smallest of the set, and independent of the rest.

Found while porting flexPTP to an STM32H563 (NUCLEO-H563ZI) running ThreadX through the CMSIS-RTOS2 binding with lwIP as the network stack, in an application that samples two SCH16T IMUs at 8 kHz and timestamps them off the PTP-disciplined clock. This has been running with the fix applied since.

## The change

One commit, based on `master` `76aaf67` (RC1.0-11 — current `HEAD` when this was written). It rebases cleanly onto `pdel_fix` too, so this can target either branch. I checked the hunk still lands in the right place in the `ptp_transmit()` that branch refactored.

1. lwIP NSD: check pbuf_alloc() before writing through it

Rebasing or squashing to taste is fine by me — say the word and I will reshape it.
