### PR TITLE
Let a port supply its own IGMP group addresses

### DIFF
--- a/src/flexptp/ptp_defs.c
+++ b/src/flexptp/ptp_defs.c
@@ -9,6 +9,14 @@ const ip_addr_t PTP_IGMP_PEER_DELAY = { 0x6B0000E0 }; // 224.0.0.107
 #elif defined(ETHLIB)
 const ip_addr_t PTP_IGMP_PRIMARY = IPv4(224, 0, 1, 129); // 224.0.1.129
 const ip_addr_t PTP_IGMP_PEER_DELAY = IPv4(224, 0, 0, 107); // 224.0.0.107
+#elif defined(PTP_IGMP_PRIMARY_INIT) && defined(PTP_IGMP_PEER_DELAY_INIT)
+// Network stack supplied by the port. The #error below already asks the integrator to
+// "define PTP_IGMP_PRIMARY and PTP_IGMP_PEER_DELAY", but offered no mechanism to do so:
+// both are const objects defined here, so a port could not provide them without editing
+// this file. These two macros are that mechanism -- give them a brace initialiser matching
+// whatever ip_addr_t the port's flexptp_options.h declares.
+const ip_addr_t PTP_IGMP_PRIMARY = PTP_IGMP_PRIMARY_INIT;       // 224.0.1.129
+const ip_addr_t PTP_IGMP_PEER_DELAY = PTP_IGMP_PEER_DELAY_INIT; // 224.0.0.107
 #else // unkown network stack
-#error "Hence the network stack is unknown, please define PTP_IGMP_PRIMARY and PTP_IGMP_PEER_DELAY IPv4 addresses!"
+#error "Hence the network stack is unknown, please define PTP_IGMP_PRIMARY_INIT and PTP_IGMP_PEER_DELAY_INIT!"
 #endif


### PR DESCRIPTION
An ergonomics fix rather than a bug, and the only one of these that changes an interface, so it is on its own and can be argued about without holding anything else up.

The #error at the end of `ptp_defs.c` asks the integrator to "define `PTP_IGMP_PRIMARY` and `PTP_IGMP_PEER_DELAY`", but there is no way to comply: both are const objects defined in that same file. A port bringing its own network stack has to edit `ptp_defs.c` to build at all — exactly the kind of local change that makes updating flexPTP painful later.

This adds `PTP_IGMP_PRIMARY_INIT` / `PTP_IGMP_PEER_DELAY_INIT` as the mechanism the #error was already assuming, and updates the message to name macros that now exist. The lwIP and EtherLib branches are untouched and still take precedence, so nothing changes for existing users.

I am not attached to the spelling. If you would prefer different names or a different shape entirely, say so and I will redo it.

Found while porting flexPTP to an STM32H563 (NUCLEO-H563ZI) running ThreadX through the CMSIS-RTOS2 binding with lwIP as the network stack, in an application that samples two SCH16T IMUs at 8 kHz and timestamps them off the PTP-disciplined clock. This has been running with the fix applied since.

## The change

One commit, based on `master` `76aaf67` (RC1.0-11 — current `HEAD` when this was written). It rebases cleanly onto `pdel_fix` too, so this can target either branch.

1. Let a port supply the IGMP group addresses for its own network stack

Rebasing or squashing to taste is fine by me — say the word and I will reshape it.
